### PR TITLE
make use of includes to reduce code duplication

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -3,4 +3,5 @@ default: true
 MD013: false
 MD024: false
 MD033: false
+MD041: false
 MD046: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,6 @@ repos:
       - id: markdownlint
         args:
           - "--fix"
-          - "docs/**/*.md"
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
     hooks:
@@ -26,7 +25,6 @@ repos:
       - id: detect-private-key
       - id: no-commit-to-branch
       - id: requirements-txt-fixer
-
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.26.3
     hooks:

--- a/docs/advanced/mqtt/json/commands/general.md
+++ b/docs/advanced/mqtt/json/commands/general.md
@@ -88,14 +88,15 @@ In general a response looks like:
   - `code`: Error code; `0` means no error, command was executed successfully
   - `msg`: Description for the error code
 
-## Set commands
+## Execute commands
 
-Set commands have different requests, but the response has always the same schema, if not other mentioned.
+Execute commands have different requests, but the response has always the same schema, if not other mentioned.
 
 ### Response
 
-Only the `body` object will be described here.
-To get information about the whole response, please refer to [response](#response)
+{%
+   include-markdown "../../../../../include/advanced/mqtt/json/commands/request.md"
+%}
 
 ```json
 {

--- a/docs/advanced/mqtt/json/commands/map.md
+++ b/docs/advanced/mqtt/json/commands/map.md
@@ -6,15 +6,18 @@ Command to get information about the maps.
 
 ### Request
 
-Only the name and the arguments will be described. General information can be found under [Command General](general.md#request)
+{%
+    include-markdown "../../../../../include/advanced/mqtt/json/commands/request.md"
+%}
 
 - Name: `getCachedMapInfo`
 - Arguments: None
 
 ### Response
 
-Only the `data` object will be described here.
-To get information about the whole response, please refer to [Command General](general.md#response)
+{%
+   include-markdown "../../../../../include/advanced/mqtt/json/commands/response.md"
+%}
 
 ```json
 {

--- a/docs/advanced/mqtt/json/commands/playSound.md
+++ b/docs/advanced/mqtt/json/commands/playSound.md
@@ -6,7 +6,9 @@ Command to play a sound or voice report
 
 ### Request
 
-Only the name and the arguments will be described. General information can be found under [Command General](general.md#request)
+{%
+   include-markdown "../../../../../include/advanced/mqtt/json/commands/request.md"
+%}
 
 - Name: `playSound`
 - Arguments:
@@ -15,3 +17,8 @@ Only the name and the arguments will be described. General information can be fo
 !!! info "Available sound IDs"
 
     For a list of available sound IDs see [here](https://github.com/mrbungle64/ecovacs-deebot.js/wiki/playSound#available-sound-ids)
+
+{%
+    include-markdown "../../../../../include/advanced/mqtt/json/commands/execute/response.md"
+    heading-offset=2
+%}

--- a/docs/advanced/mqtt/json/commands/stats.md
+++ b/docs/advanced/mqtt/json/commands/stats.md
@@ -6,15 +6,18 @@ Command to get information about the last or ongoing cleaning job
 
 ### Request
 
-Only the name and the arguments will be described. General information can be found under [Command General](general.md#request)
+{%
+   include-markdown "../../../../../include/advanced/mqtt/json/commands/request.md"
+%}
 
 - Name: `getStats`
 - Arguments: None
 
 ### Response
 
-Only the `data` object will be described here.
-To get information about the whole response, please refer to [Command General](general.md#response)
+{%
+   include-markdown "../../../../../include/advanced/mqtt/json/commands/response.md"
+%}
 
 ```json
 {

--- a/docs/advanced/mqtt/json/commands/volume.md
+++ b/docs/advanced/mqtt/json/commands/volume.md
@@ -6,15 +6,18 @@ Command to get information about the volume
 
 ### Request
 
-Only the name and the arguments will be described. General information can be found under [Command General](general.md#request)
+{%
+   include-markdown "../../../../../include/advanced/mqtt/json/commands/request.md"
+%}
 
 - Name: `getVolume`
 - Arguments: None
 
 ### Response
 
-Only the `data` object will be described here.
-To get information about the whole response, please refer to [Command General](general.md#response)
+{%
+   include-markdown "../../../../../include/advanced/mqtt/json/commands/response.md"
+%}
 
 ```json
 {
@@ -32,12 +35,15 @@ Command to set volume
 
 ### Request
 
-Only the name and the arguments will be described. General information can be found under [Command General](general.md#request)
+{%
+   include-markdown "../../../../../include/advanced/mqtt/json/commands/request.md"
+%}
 
 - Name: `setVolume`
 - Arguments:
   - `volume`: The level to set the volume
 
-### Response
-
-Please refer to [set commands](general.md#set-commands).
+{%
+    include-markdown "../../../../../include/advanced/mqtt/json/commands/execute/response.md"
+    heading-offset=2
+%}

--- a/docs/advanced/mqtt/json/commands/water.md
+++ b/docs/advanced/mqtt/json/commands/water.md
@@ -6,15 +6,18 @@ Command to get water information
 
 ### Request
 
-Only the name and the arguments will be described. General information can be found under [Command General](general.md#request)
+{%
+   include-markdown "../../../../../include/advanced/mqtt/json/commands/request.md"
+%}
 
 - Name: `getWaterInfo`
 - Arguments: None
 
 ### Response
 
-Only the `data` object will be described here.
-To get information about the whole response, please refer to [Command General](general.md#response)
+{%
+   include-markdown "../../../../../include/advanced/mqtt/json/commands/response.md"
+%}
 
 ```json
 {
@@ -36,12 +39,15 @@ Command to set the water amount
 
 ### Request
 
-Only the name and the arguments will be described. General information can be found under [Command General](general.md#request)
+{%
+   include-markdown "../../../../../include/advanced/mqtt/json/commands/request.md"
+%}
 
 - Name: `setWaterInfo`
 - Arguments:
   - `amount`: The water amount. Available values are specified in [getWaterInfo](#getwaterinfo).
 
-### Response
-
-Please refer to [set commands](general.md#set-commands).
+{%
+    include-markdown "../../../../../include/advanced/mqtt/json/commands/execute/response.md"
+    heading-offset=2
+%}

--- a/docs/advanced/mqtt/json/messages/stats.md
+++ b/docs/advanced/mqtt/json/messages/stats.md
@@ -4,8 +4,9 @@
 
 This message will be sent out on the start and on the end (stop) of a cleaning job.
 
-Only the `data` object will be described here.
-To get information about the whole message, please refer to [Messages](index.md#messages)
+{%
+   include-markdown "../../../../../include/advanced/mqtt/json/messages/general.md"
+%}
 
 ```json
 {

--- a/include/advanced/mqtt/json/commands/execute/response.md
+++ b/include/advanced/mqtt/json/commands/execute/response.md
@@ -1,0 +1,3 @@
+# Response
+
+Please refer to [execute commands](../../../../../../docs/advanced/mqtt/json/commands/general.md#execute-commands).

--- a/include/advanced/mqtt/json/commands/request.md
+++ b/include/advanced/mqtt/json/commands/request.md
@@ -1,0 +1,2 @@
+Only the name and the arguments will be described. General information can be found
+under [Command General](../../../../../docs/advanced/mqtt/json/commands/general.md#request).

--- a/include/advanced/mqtt/json/commands/response.md
+++ b/include/advanced/mqtt/json/commands/response.md
@@ -1,0 +1,3 @@
+Only the `data` object will be described here.
+To get information about the whole response, please refer to
+[Command General](../../../../../docs/advanced/mqtt/json/commands/general.md#response).

--- a/include/advanced/mqtt/json/messages/general.md
+++ b/include/advanced/mqtt/json/messages/general.md
@@ -1,0 +1,3 @@
+Only the `data` object will be described here.
+To get information about the whole message, please refer to
+[Messages](../../../../../docs/advanced/mqtt/json/messages/index.md#messages)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,10 @@ markdown_extensions:
   - pymdownx.highlight
   - pymdownx.superfences
 
+plugins:
+  # https://github.com/mondeja/mkdocs-include-markdown-plugin
+  - include-markdown
+
 nav:
   - Home:
       - index.md
@@ -70,7 +74,7 @@ nav:
                   - advanced/mqtt/json/commands/index.md
                   - General: advanced/mqtt/json/commands/general.md
                   - Map: advanced/mqtt/json/commands/map.md
-                  - Play sound: advanced/mqtt/json/commands/playSound.md
+                  - PlaySound: advanced/mqtt/json/commands/playSound.md
                   - Stats: advanced/mqtt/json/commands/stats.md
                   - Volume: advanced/mqtt/json/commands/volume.md
                   - Water: advanced/mqtt/json/commands/water.md
@@ -81,4 +85,4 @@ nav:
               - Commands:
                   - advanced/mqtt/xml/commands/index.md
                   - General: advanced/mqtt/xml/commands/general.md
-                  - Play sound: advanced/mqtt/xml/commands/playSound.md
+                  - PlaySound: advanced/mqtt/xml/commands/playSound.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mdx_truly_sane_lists==1.2
 mkdocs===1.2.3
+mkdocs-include-markdown-plugin==3.2.3
 mkdocs-material==7.3.6


### PR DESCRIPTION
[MD041](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md041---first-line-in-a-file-should-be-a-top-level-heading) deactivates as includes don't need to start with a header