### PR TITLE
Add auto-empty command to examples

### DIFF
--- a/docs/integrations/home-assistant/examples/commands.md
+++ b/docs/integrations/home-assistant/examples/commands.md
@@ -57,3 +57,16 @@ data:
     3. At the end of the job you can find your coordinates under `data->content`
 
     Also the coordinates will be logged on `debug`. After activating debug logs, you can search your logs for `Last custom area values (x1,y1,x2,y2):` to get the coordinates.
+
+## Empty dustbin to aute-empty station
+
+```yaml
+# Customize Clean
+service: vacuum.send_command
+target:
+  entity_id: vacuum.YOUR_ROBOT_NAME
+data:
+  command: setAutoEmpty
+  params:
+    act: start
+```

--- a/docs/integrations/home-assistant/examples/commands.md
+++ b/docs/integrations/home-assistant/examples/commands.md
@@ -60,7 +60,7 @@ data:
 
 ## Empty dustbin with auto-empty station
 
-Manually start empting the dustbin, when the robot is dokced on a auto-empty station.
+Manually start empting the dustbin, when the robot is docked on a auto-empty station.
 
 ```yaml
 service: vacuum.send_command

--- a/docs/integrations/home-assistant/examples/commands.md
+++ b/docs/integrations/home-assistant/examples/commands.md
@@ -58,7 +58,7 @@ data:
 
     Also the coordinates will be logged on `debug`. After activating debug logs, you can search your logs for `Last custom area values (x1,y1,x2,y2):` to get the coordinates.
 
-## Empty dustbin to aute-empty station
+## Empty dustbin to auto-empty station
 
 ```yaml
 # Customize Clean

--- a/docs/integrations/home-assistant/examples/commands.md
+++ b/docs/integrations/home-assistant/examples/commands.md
@@ -58,10 +58,11 @@ data:
 
     Also the coordinates will be logged on `debug`. After activating debug logs, you can search your logs for `Last custom area values (x1,y1,x2,y2):` to get the coordinates.
 
-## Empty dustbin to auto-empty station
+## Empty dustbin with auto-empty station
+
+Manually start empting the dustbin, when the robot is dokced on a auto-empty station.
 
 ```yaml
-# Customize Clean
 service: vacuum.send_command
 target:
   entity_id: vacuum.YOUR_ROBOT_NAME


### PR DESCRIPTION
it's a great feature, needs to be in the docs.
Also think the switches created should be explained somewhere. Maybe a new subheader "settings"?